### PR TITLE
Use property to define shell link name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Windows-specific implementations of [integrations-api](https://github.com/crypto
 ## Config
 
 This project uses the following JVM properties:
-* `org.cryptomator.integrations_win.autostart.shellinkname` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
+* `org.cryptomator.integrations_win.autostart.shellLinkName` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Windows-specific implementations of [integrations-api](https://github.com/crypto
 ## Config
 
 This project uses the following JVM properties:
-* `org.cryptomator.integrations_win.autostart.shell_link_name` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
+* `cryptomator.integrationsWin.autoStartShellLinkName` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Windows-specific implementations of [integrations-api](https://github.com/crypto
 ## Config
 
 This project uses the following JVM properties:
-* `org.cryptomator.integrations_win.autostart.shellLinkName` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
+* `org.cryptomator.integrations_win.autostart.shell_link_name` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Windows-specific implementations of [integrations-api](https://github.com/cryptomator/integrations-api).
 
+## Config
+
+This project uses the following JVM properties:
+* `org.cryptomator.integrations_win.autostart.shellinkname` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
+
 ## Building
 
 This project uses JNI, hence you'll nedd Java as well as GCC build tools:

--- a/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
@@ -27,7 +27,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 	private static final Logger LOG = LoggerFactory.getLogger(WindowsAutoStart.class);
 	private static final String RELATIVE_STARTUP_FOLDER = "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
 	private static final String LNK_FILE_EXTENSION = ".lnk";
-	private static final String LNK_NAME_PROPERTY = "org.cryptomator.integrations_win.autostart.shell_link_name";
+	private static final String LNK_NAME_PROPERTY = "cryptomator.integrationsWin.autoStartShellLinkName";
 
 	private final WinShellLinks winShellLinks;
 	private final Optional<String> shellLinkName;

--- a/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * Checks, en- and disables autostart for an application on Windows using the startup folder.
  * <p>
  * The above actions are done by checking/adding/removing in the directory {@value RELATIVE_STARTUP_FOLDER} a shell link (.lnk).
- * The filename of the shell link is given by the JVM property {@value LNK_NAME_PROPERTY}. If the property is not set at class initialization, the start command of the calling process is used.
+ * The filename of the shell link is given by the JVM property {@value LNK_NAME_PROPERTY}. If the property is not set before object creation, the start command of the calling process is used.
  */
 @Priority(1000)
 @OperatingSystem(OperatingSystem.Value.WINDOWS)

--- a/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
@@ -29,7 +29,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 	private static final Logger LOG = LoggerFactory.getLogger(WindowsAutoStart.class);
 	private static final String RELATIVE_STARTUP_FOLDER = "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
 	private static final String LNK_FILE_EXTENSION = ".lnk";
-	private static final String LNK_NAME_PROPERTY = "org.cryptomator.integrations_win.autostart.shellLinkName";
+	private static final String LNK_NAME_PROPERTY = "org.cryptomator.integrations_win.autostart.shell_link_name";
 
 	private final WinShellLinks winShellLinks;
 	private final Supplier<Path> absoluteStartupEntryPath;
@@ -39,7 +39,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 	public WindowsAutoStart() {
 		this.winShellLinks = new WinShellLinks();
 		this.exePath = ProcessHandle.current().info().command();
-		this.absoluteStartupEntryPath = () -> Path.of(System.getProperty("user.home"), RELATIVE_STARTUP_FOLDER, this.getShellinkName() + LNK_FILE_EXTENSION).toAbsolutePath();
+		this.absoluteStartupEntryPath = () -> Path.of(System.getProperty("user.home"), RELATIVE_STARTUP_FOLDER, this.getShellLinkName() + LNK_FILE_EXTENSION).toAbsolutePath();
 	}
 
 	@Override
@@ -58,7 +58,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 		}
 
 		assert exePath.isPresent();
-		int returnCode = winShellLinks.createShortcut(exePath.get(), absoluteStartupEntryPath.toString(), getShellinkName());
+		int returnCode = winShellLinks.createShortcut(exePath.get(), absoluteStartupEntryPath.toString(), getShellLinkName());
 		if (returnCode == 0) {
 			LOG.debug("Successfully created {}.", absoluteStartupEntryPath.get());
 		} else {
@@ -72,7 +72,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 			Files.delete(absoluteStartupEntryPath.get());
 			LOG.debug("Successfully deleted {}.", absoluteStartupEntryPath.get());
 		} catch (NoSuchElementException e) {
-			throw new ToggleAutoStartFailedException("Disabling auto start failed using startup folder: Name of shellink is not defined.");
+			throw new ToggleAutoStartFailedException("Disabling auto start failed using startup folder: Name of shell link is not defined.");
 		} catch (NoSuchFileException e) {
 			//also okay
 			LOG.debug("File {} not present. Nothing to do.", absoluteStartupEntryPath.get());
@@ -82,7 +82,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 		}
 	}
 
-	private String getShellinkName() throws NoSuchElementException {
+	private String getShellLinkName() throws NoSuchElementException {
 		var name = System.getProperty(LNK_NAME_PROPERTY);
 		return Objects.requireNonNullElseGet(name, //
 				() -> exePath.map(s -> s.substring(s.lastIndexOf('\\') + 1, s.lastIndexOf('.'))).get() //

--- a/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
@@ -29,7 +29,7 @@ public class WindowsAutoStart implements AutoStartProvider {
 	private static final Logger LOG = LoggerFactory.getLogger(WindowsAutoStart.class);
 	private static final String RELATIVE_STARTUP_FOLDER = "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
 	private static final String LNK_FILE_EXTENSION = ".lnk";
-	private static final String LNK_NAME_PROPERTY = "org.cryptomator.integrations_win.autostart.shellinkname";
+	private static final String LNK_NAME_PROPERTY = "org.cryptomator.integrations_win.autostart.shellLinkName";
 
 	private final WinShellLinks winShellLinks;
 	private final Supplier<Path> absoluteStartupEntryPath;


### PR DESCRIPTION
This PR refactors the Autostart service impl to be more customizable.

The hard coded Cryptomator references are removed, instead the used shell link is named with the JVM property `cryptomator.integrationsWin.autoStartShellLinkName`.

Edit: Fixed property name
Edit2: Use snake case
Edit3: Final property name change