### PR TITLE
Renamed keychain path property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Windows-specific implementations of [integrations-api](https://github.com/crypto
 
 This project uses the following JVM properties:
 * `cryptomator.integrationsWin.autoStartShellLinkName` - Name of the shell link, which is placed in the Windows startup folder to start application on user login
+* `cryptomator.integrationsWin.keychainPaths` - Colon separated list of paths, which are checked for encrypted data
 
 ## Building
 

--- a/src/main/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccess.java
+++ b/src/main/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccess.java
@@ -37,10 +37,15 @@ import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * Windows implementation for the {@link KeychainAccessProvider} based on the <a href="https://en.wikipedia.org/wiki/Data_Protection_API">data protection API</a>.
+ * The storage locations to check for encrypted data can be set with the JVM property {@value KEYCHAIN_PATHS_PROPERTY} as a colon({@value PATH_LIST_SEP}) separated list of paths.
+ */
 @Priority(1000)
 @OperatingSystem(OperatingSystem.Value.WINDOWS)
 public class WindowsProtectedKeychainAccess implements KeychainAccessProvider {
 
+	private static final String KEYCHAIN_PATHS_PROPERTY = "cryptomator.integrationsWin.keychainPaths";
 	private static final Logger LOG = LoggerFactory.getLogger(WindowsProtectedKeychainAccess.class);
 	private static final String PATH_LIST_SEP = ":";
 	private static final Path USER_HOME_REL = Path.of("~");
@@ -67,16 +72,12 @@ public class WindowsProtectedKeychainAccess implements KeychainAccessProvider {
 	}
 
 	private static List<Path> readKeychainPathsFromEnv() {
-		String rawPaths = System.getProperty("cryptomator.keychainPath");
-		if (rawPaths == null) {
-			return List.of();
-		} else {
-			return Arrays.stream(rawPaths.split(PATH_LIST_SEP))
-					.filter(Predicate.not(String::isEmpty))
-					.map(Path::of)
-					.map(WindowsProtectedKeychainAccess::resolveHomeDir)
-					.collect(Collectors.toList());
-		}
+		return Optional.ofNullable(System.getProperty(KEYCHAIN_PATHS_PROPERTY))
+				.stream().flatMap(rawPaths -> Arrays.stream(rawPaths.split(PATH_LIST_SEP)))
+				.filter(Predicate.not(String::isEmpty))
+				.map(Path::of)
+				.map(WindowsProtectedKeychainAccess::resolveHomeDir)
+				.collect(Collectors.toList());
 	}
 
 	private static Path resolveHomeDir(Path path) {

--- a/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
+++ b/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
@@ -9,19 +9,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 public class KeychainAccessProviderTest {
 
 	@BeforeAll
 	public static void setup(@TempDir Path tmpDir) {
 		Path keychainPath = tmpDir.resolve("keychain.tmp");
-		System.setProperty("cryptomator.keychainPath", keychainPath.toString());
+		System.setProperty("cryptomator.integrationsWin.keychainPaths", keychainPath.toString());
 	}
 
 	@Test
 	@DisplayName("WindowsProtectedKeychainAccess can be loaded")
 	public void testLoadWindowsProtectedKeychainAccess() {
-		Assumptions.assumeFalse(System.getProperty("cryptomator.keychainPath", "").isBlank());
+		Assertions.assertTrue(Objects.nonNull(System.getProperty("cryptomator.integrationsWin.keychainPaths")));
 		
 		var windowsKeychainAccessProvider = KeychainAccessProvider.get().findAny();
 		Assertions.assertTrue(windowsKeychainAccessProvider.isPresent());

--- a/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
+++ b/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
@@ -40,8 +40,8 @@ public class KeychainAccessProviderTest {
 		WindowsProtectedKeychainAccess keychainAccess;
 
 		@BeforeEach
-		public void init() throws IOException {
-			keychainPath = Path.of(System.getProperty("cryptomator.integrationsWin.keychainPaths"));
+		public void init(@TempDir Path tmpDir) throws IOException {
+			keychainPath = tmpDir.resolve("keychain.tmp");
 			Files.write(keychainPath, new byte[] {});
 			keychainAccess = (WindowsProtectedKeychainAccess) KeychainAccessProvider.get().findAny().get();
 		}

--- a/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
+++ b/src/test/java/org/cryptomator/windows/keychain/KeychainAccessProviderTest.java
@@ -26,9 +26,8 @@ public class KeychainAccessProviderTest {
 	@Test
 	@DisplayName("WindowsProtectedKeychainAccess can be loaded")
 	public void testLoadWindowsProtectedKeychainAccess() {
-		Assertions.assertTrue(Objects.nonNull(System.getProperty("cryptomator.integrationsWin.keychainPaths")));
-
 		var windowsKeychainAccessProvider = KeychainAccessProvider.get().findAny();
+
 		Assertions.assertTrue(windowsKeychainAccessProvider.isPresent());
 		Assertions.assertInstanceOf(WindowsProtectedKeychainAccess.class, windowsKeychainAccessProvider.get());
 	}
@@ -40,22 +39,22 @@ public class KeychainAccessProviderTest {
 		WindowsProtectedKeychainAccess keychainAccess;
 
 		@BeforeEach
-		public void init(@TempDir Path tmpDir) throws IOException {
+		public void init(@TempDir Path tmpDir) {
 			keychainPath = tmpDir.resolve("keychain.tmp");
-			Files.write(keychainPath, new byte[] {});
 			keychainAccess = (WindowsProtectedKeychainAccess) KeychainAccessProvider.get().findAny().get();
 		}
 
 		@Test
 		public void testNonExistingFileReturnsEmpty() throws KeychainAccessException, IOException {
-			Files.delete(keychainPath);
 			var result = keychainAccess.loadKeychainEntries(keychainPath);
 
 			Assertions.assertTrue(result.isEmpty());
 		}
 
 		@Test
-		public void testEmptyFileReturnsEmpty() throws KeychainAccessException {
+		public void testEmptyFileReturnsEmpty() throws KeychainAccessException, IOException {
+			Files.write(keychainPath, new byte[] {});
+
 			var result = keychainAccess.loadKeychainEntries(keychainPath);
 
 			Assertions.assertTrue(result.isEmpty());


### PR DESCRIPTION
This aligns the name of the used JVM property with other property names.

Additionally:
* added java doc
* adjusted unit test
* documented usage in README