### PR TITLE
Feature: Use startup folder defined by Windows

### DIFF
--- a/src/main/headers/org_cryptomator_windows_autostart_WinShellLinks_Native.h
+++ b/src/main/headers/org_cryptomator_windows_autostart_WinShellLinks_Native.h
@@ -15,6 +15,14 @@ extern "C" {
 JNIEXPORT jint JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_00024Native_createShortcut
   (JNIEnv *, jobject, jbyteArray, jbyteArray, jbyteArray);
 
+/*
+ * Class:     org_cryptomator_windows_autostart_WinShellLinks_Native
+ * Method:    createAndGetStartupFolderPath
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_00024Native_createAndGetStartupFolderPath
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/java/org/cryptomator/windows/autostart/WinShellLinks.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WinShellLinks.java
@@ -15,7 +15,7 @@ public class WinShellLinks {
 	/**
 	 * Create a Windows shortcut file to the given target, at the specified location and with a description.
 	 *
-	 * @param target path of the target the shortcut points to
+	 * @param target      path of the target the shortcut points to
 	 * @param storagePath path where the shortcut is created
 	 * @param description string inserted in the description field of the shortcut.
 	 * @return {@code 0} if everything worked, otherwise an HRESULT error code
@@ -26,6 +26,15 @@ public class WinShellLinks {
 				getNullTerminatedUTF16Representation(storagePath),
 				getNullTerminatedUTF16Representation(description)
 		);
+	}
+
+	/**
+	 * Gets the file system path of the startup folder. Creates all directories in the path, if necessary.
+	 *
+	 * @return path to the startup folder with no trailing \ or {@code null}, if the folder is not defined or cannot be created
+	 */
+	public String getPathToStartupFolder() {
+		return Native.INSTANCE.createAndGetStartupFolderPath();
 	}
 
 	// visible for testing
@@ -41,6 +50,8 @@ public class WinShellLinks {
 			NativeLibLoader.loadLib();
 		}
 
-		public synchronized native int createShortcut(byte[] target, byte[] storagePath, byte[] description);
+		synchronized native int createShortcut(byte[] target, byte[] storagePath, byte[] description);
+
+		native String createAndGetStartupFolderPath();
 	}
 }

--- a/src/main/java/org/cryptomator/windows/autostart/WinShellLinks.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WinShellLinks.java
@@ -15,8 +15,8 @@ public class WinShellLinks {
 	/**
 	 * Create a Windows shortcut file to the given target, at the specified location and with a description.
 	 *
-	 * @param target      path of the target the shortcut points to
-	 * @param storagePath path where the shortcut is created
+	 * @param target      path of the shortcut target
+	 * @param storagePath full path where the shortcut will be created (including filename & extension)
 	 * @param description string inserted in the description field of the shortcut.
 	 * @return {@code 0} if everything worked, otherwise an HRESULT error code
 	 */
@@ -31,7 +31,7 @@ public class WinShellLinks {
 	/**
 	 * Gets the file system path of the startup folder. Creates all directories in the path, if necessary.
 	 *
-	 * @return path to the startup folder with no trailing \ or {@code null}, if the folder is not defined or cannot be created
+	 * @return path to the startup folder with no trailing \ or {@code null}, if the folder is not defined and cannot be created
 	 */
 	public String getPathToStartupFolder() {
 		return Native.INSTANCE.createAndGetStartupFolderPath();

--- a/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
+++ b/src/main/java/org/cryptomator/windows/autostart/WindowsAutoStart.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 /**
  * Checks, en- and disables autostart for an application on Windows using the startup folder.
  * <p>
- * The above actions are done by checking/adding/removing in the directory {@value RELATIVE_STARTUP_FOLDER} a shell link (.lnk).
+ * The above actions are done by checking/adding/removing a shell link (.lnk) in the Windows defined Startup directory (see also https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid#constants).
  * The filename of the shell link is given by the JVM property {@value LNK_NAME_PROPERTY}. If the property is not set before object creation, the start command of the calling process is used.
  */
 @Priority(1000)
@@ -25,13 +25,12 @@ import java.util.Optional;
 public class WindowsAutoStart implements AutoStartProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(WindowsAutoStart.class);
-	private static final String RELATIVE_STARTUP_FOLDER = "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
 	private static final String LNK_FILE_EXTENSION = ".lnk";
 	private static final String LNK_NAME_PROPERTY = "cryptomator.integrationsWin.autoStartShellLinkName";
 
 	private final WinShellLinks winShellLinks;
 	private final Optional<String> shellLinkName;
-	private final Optional<Path> absStartupEntryPath;
+	private final Optional<Path> absShellLinkPath;
 	private final Optional<Path> exePath;
 
 	@SuppressWarnings("unused") // default constructor required by ServiceLoader
@@ -39,12 +38,12 @@ public class WindowsAutoStart implements AutoStartProvider {
 		this.winShellLinks = new WinShellLinks();
 		this.exePath = ProcessHandle.current().info().command().map(Path::of);
 		this.shellLinkName = Optional.ofNullable(System.getProperty(LNK_NAME_PROPERTY)).or(() -> exePath.map(this::getExeBaseName));
-		this.absStartupEntryPath = shellLinkName.map(name -> Path.of(System.getProperty("user.home"), RELATIVE_STARTUP_FOLDER, name + LNK_FILE_EXTENSION).toAbsolutePath());
+		this.absShellLinkPath = Optional.ofNullable(winShellLinks.getPathToStartupFolder()).flatMap(p -> shellLinkName.map(name -> p + "\\" + name + LNK_FILE_EXTENSION)).map(Path::of);
 	}
 
 	@Override
 	public boolean isEnabled() {
-		return absStartupEntryPath.map(Files::exists).orElse(false);
+		return absShellLinkPath.map(Files::exists).orElse(false);
 	}
 
 	@Override
@@ -53,10 +52,10 @@ public class WindowsAutoStart implements AutoStartProvider {
 			throw new ToggleAutoStartFailedException("Enabling autostart using the startup folder failed: Path to executable is not set");
 		}
 
-		assert exePath.isPresent() && absStartupEntryPath.isPresent() && shellLinkName.isPresent();
-		int returnCode = winShellLinks.createShortcut(exePath.get().toString(), absStartupEntryPath.get().toString(), shellLinkName.get());
+		assert exePath.isPresent() && absShellLinkPath.isPresent() && shellLinkName.isPresent();
+		int returnCode = winShellLinks.createShortcut(exePath.get().toString(), absShellLinkPath.get().toString(), shellLinkName.get());
 		if (returnCode == 0) {
-			LOG.debug("Successfully created {}.", absStartupEntryPath.get());
+			LOG.debug("Successfully created {}.", absShellLinkPath.get());
 		} else {
 			throw new ToggleAutoStartFailedException("Enabling autostart using the startup folder failed. Windows error code: " + Integer.toHexString(returnCode));
 		}
@@ -65,13 +64,13 @@ public class WindowsAutoStart implements AutoStartProvider {
 	@Override
 	public synchronized void disable() throws ToggleAutoStartFailedException {
 		try {
-			Files.delete(absStartupEntryPath.get());
-			LOG.debug("Successfully deleted {}.", absStartupEntryPath.get());
+			Files.delete(absShellLinkPath.get());
+			LOG.debug("Successfully deleted {}.", absShellLinkPath.get());
 		} catch (NoSuchElementException e) { //thrown by Optional::get
 			throw new ToggleAutoStartFailedException("Disabling auto start failed using startup folder: Name of shell link is not defined.");
 		} catch (NoSuchFileException e) {
 			//also okay
-			LOG.debug("File {} not present. Nothing to do.", absStartupEntryPath.get());
+			LOG.debug("File {} not present. Nothing to do.", absShellLinkPath.get());
 		} catch (IOException e) {
 			LOG.debug("Failed to delete entry from auto start folder.", e);
 			throw new ToggleAutoStartFailedException("Disabling auto start failed using startup folder.", e);

--- a/src/main/native/org_cryptomator_windows_autostart_WinShellLinks_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_autostart_WinShellLinks_Native.cpp
@@ -22,8 +22,9 @@ const GUID StartupFolderGUID = {
 
 JNIEXPORT jstring JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_00024Native_createAndGetStartupFolderPath
   (JNIEnv * env, jobject thisObj) {
-
     HRESULT hres;
+    jstring result = NULL;
+
     PWSTR startupfolder_path;
     hres = SHGetKnownFolderPath(StartupFolderGUID, KF_FLAG_CREATE | KF_FLAG_INIT, NULL, &startupfolder_path); //returns C:\Home, not C:\Home\ (NO trailing slash)
     if(FAILED(hres)) {
@@ -32,13 +33,11 @@ JNIEXPORT jstring JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_0
 
     size_t length_startupfolder_path;
     hres = StringCbLengthW(startupfolder_path, STRSAFE_MAX_CCH * sizeof(TCHAR), &length_startupfolder_path);
-    if(FAILED(hres)) {
-        CoTaskMemFree(startupfolder_path);
-        return NULL;
+    if(SUCCEEDED(hres)) {
+        result = env->NewString( (jchar *) startupfolder_path, length_startupfolder_path/sizeof(WCHAR) );
     }
-    jstring s = env->NewString( (jchar *) startupfolder_path, length_startupfolder_path/sizeof(WCHAR) );
     CoTaskMemFree(startupfolder_path);
-    return s;
+    return result;
 };
 
 

--- a/src/main/native/org_cryptomator_windows_autostart_WinShellLinks_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_autostart_WinShellLinks_Native.cpp
@@ -5,6 +5,8 @@
 #include <jni.h>
 #include <windows.h>
 #include <winnls.h>
+#include <shlobj.h>
+#include <strsafe.h>
 #include <shobjidl.h>
 #include <objbase.h>
 #include <objidl.h>
@@ -12,6 +14,33 @@
 #include "org_cryptomator_windows_autostart_WinShellLinks_Native.h"
 
 HRESULT CreateLink(LPCWSTR lpszPathObj, LPCWSTR lpszPathLink, LPCWSTR lpszDesc);
+//GUID of the Startup Folder: {B97D20BB-F46A-4C97-BA10-5E3608430854}
+const GUID StartupFolderGUID = {
+    0xB97D20BBu,0xF46Au,0x4C97u, 0xBAu, 0x10u, 0x5Eu,0x36u, 0x08u, 0x43u, 0x08u, 0x54u
+};
+
+
+JNIEXPORT jstring JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_00024Native_createAndGetStartupFolderPath
+  (JNIEnv * env, jobject thisObj) {
+
+    HRESULT hres;
+    PWSTR startupfolder_path;
+    hres = SHGetKnownFolderPath(StartupFolderGUID, KF_FLAG_CREATE | KF_FLAG_INIT, NULL, &startupfolder_path); //returns C:\Home, not C:\Home\ (NO trailing slash)
+    if(FAILED(hres)) {
+        return NULL;
+    }
+
+    size_t length_startupfolder_path;
+    hres = StringCbLengthW(startupfolder_path, STRSAFE_MAX_CCH * sizeof(TCHAR), &length_startupfolder_path);
+    if(FAILED(hres)) {
+        CoTaskMemFree(startupfolder_path);
+        return NULL;
+    }
+    jstring s = env->NewString( (jchar *) startupfolder_path, length_startupfolder_path/sizeof(WCHAR) );
+    CoTaskMemFree(startupfolder_path);
+    return s;
+};
+
 
 JNIEXPORT jint JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_00024Native_createShortcut
   (JNIEnv * env, jobject thisObj, jbyteArray target, jbyteArray storage_path, jbyteArray description) {
@@ -41,6 +70,7 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_windows_autostart_WinShellLinks_0002
 
     return hres;
 }
+
 
 // CreateLink - Uses the Shell's IShellLink and IPersistFile interfaces
 //              to create and store a shortcut to the specified object.
@@ -87,5 +117,5 @@ HRESULT CreateLink(LPCWSTR lpszPathObj, LPCWSTR lpszPathLink, LPCWSTR lpszDesc) 
         }
         psl->Release();
     }
-return hres;
+    return hres;
 }

--- a/src/test/java/org/cryptomator/windows/autostart/WinShellLinksTest.java
+++ b/src/test/java/org/cryptomator/windows/autostart/WinShellLinksTest.java
@@ -23,6 +23,8 @@ public class WinShellLinksTest {
 	private Path linkTarget;
 	private Path shortcut;
 
+	private WinShellLinks inTest = new WinShellLinks();
+
 	@BeforeEach
 	public void setup(@TempDir Path tempDir) throws IOException {
 		this.linkTarget = tempDir.resolve("link.target");
@@ -31,16 +33,14 @@ public class WinShellLinksTest {
 
 	@Test
 	public void testGetStartupFolderPath() {
-		WinShellLinks winShellLinks = new WinShellLinks();
-		Assertions.assertDoesNotThrow(() -> winShellLinks.getPathToStartupFolder());
+		Assertions.assertDoesNotThrow(() -> inTest.getPathToStartupFolder());
 	}
 
 	@Test
 	public void testShellLinkCreation() {
-		WinShellLinks winShellLinks = new WinShellLinks();
 		shortcut = linkTarget.getParent().resolve("short.lnk");
 
-		int returnCode = winShellLinks.createShortcut(linkTarget.toString(), shortcut.toString(), "asd");
+		int returnCode = inTest.createShortcut(linkTarget.toString(), shortcut.toString(), "asd");
 
 		Assertions.assertEquals(0, returnCode);
 		Assertions.assertTrue(Files.exists(shortcut));
@@ -52,9 +52,7 @@ public class WinShellLinksTest {
 			"bar, '62 00 61 00 72 00 00 00'"
 	})
 	public void testGetNullTerminatedUTF16Representation(String input, @ConvertWith(ByteArrayConverter.class) byte[] expected) {
-		WinShellLinks winShellLinks = new WinShellLinks();
-
-		var result = winShellLinks.getNullTerminatedUTF16Representation(input);
+		var result = inTest.getNullTerminatedUTF16Representation(input);
 
 		Assertions.assertArrayEquals(expected, result);
 	}

--- a/src/test/java/org/cryptomator/windows/autostart/WinShellLinksTest.java
+++ b/src/test/java/org/cryptomator/windows/autostart/WinShellLinksTest.java
@@ -30,6 +30,12 @@ public class WinShellLinksTest {
 	}
 
 	@Test
+	public void testGetStartupFolderPath() {
+		WinShellLinks winShellLinks = new WinShellLinks();
+		Assertions.assertDoesNotThrow(() -> winShellLinks.getPathToStartupFolder());
+	}
+
+	@Test
 	public void testShellLinkCreation() {
 		WinShellLinks winShellLinks = new WinShellLinks();
 		shortcut = linkTarget.getParent().resolve("short.lnk");


### PR DESCRIPTION
This PR improves the auto start service by always storing the shortcut file in the _windows defined_ startup folder (see also https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid).

To get startup folder path, a native call is made returning either a String or null, if any error occurs.