### PR TITLE
Add a secure cache to Windows Hello to make it usable (amount of prompts)

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.cryptomator.integrations.win {
 	opens org.cryptomator.windows.quickaccess to org.cryptomator.integrations.api;
 
 	provides AutoStartProvider with WindowsAutoStart;
-	provides KeychainAccessProvider with WindowsProtectedKeychainAccess;
+	provides KeychainAccessProvider with WindowsProtectedKeychainAccess, WindowsHelloKeychainAccess;
 	provides UiAppearanceProvider with WinUiAppearanceProvider;
 	provides RevealPathService with ExplorerRevealPathService;
 	provides QuickAccessService with ExplorerQuickAccessService;

--- a/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
@@ -189,14 +189,11 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
             std::lock_guard<std::mutex> lock(cacheMutex);
             auto it = keyCache.find(challenge);
             if (it != keyCache.end()) {
-                std::cerr << "Found signature in cache." << std::endl;
                 signatureData = it->second;
                 if (!UnprotectMemory(signatureData)) {
                     throw std::runtime_error("Failed to unprotect memory.");
                 }
                 foundInCache = true;
-            } else {
-                std::cerr << "Could not find signature in cache." << std::endl;
             }
         }
 
@@ -230,7 +227,6 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
 
             // Store in cache
             {
-                std::cerr << "Storing signature in cache." << std::endl;
                 std::lock_guard<std::mutex> lock(cacheMutex);
                 keyCache[challenge] = protectCopy;
             }

--- a/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
@@ -230,6 +230,7 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
                 std::lock_guard<std::mutex> lock(cacheMutex);
                 keyCache[challenge] = protectCopy;
             }
+            std::fill(protectCopy.begin(), protectCopy.end(), 0);
         }
 
         auto signatureBuffer = CryptographicBuffer::CreateFromByteArray(
@@ -239,7 +240,6 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
         IBuffer info = CryptographicBuffer::ConvertStringToBinary(HKDF_INFO, BinaryStringEncoding::Utf8);
         key = DeriveKeyUsingHKDF(signatureBuffer, challengeBuffer, 32, info); // needs to be 32 bytes for SHA256
         std::fill(signatureData.begin(), signatureData.end(), 0);
-        std::fill(protectCopy.begin(), protectCopy.end(), 0);
 
         return true;
     }

--- a/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
@@ -47,7 +47,7 @@ bool UnprotectMemory(std::vector<uint8_t>& data) {
 
 std::vector<uint8_t> SerializeKeyCredential(const winrt::Windows::Security::Credentials::KeyCredential& credential) {
     // Serialize key reference (assuming `KeyCredential` can be serialized this way)
-    std::wstring keyStr = credential.Name();
+    std::wstring keyStr = credential.Name().c_str();
     std::vector<uint8_t> data(reinterpret_cast<const uint8_t*>(keyStr.data()),
                               reinterpret_cast<const uint8_t*>(keyStr.data()) + keyStr.size() * sizeof(wchar_t));
 
@@ -181,7 +181,7 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
         array_view<const uint8_t>(challenge.data(), challenge.size()));
 
     try {
-        KeyCredential credential;
+        KeyCredential credential = nullptr;
 
         {
             // Lock for thread safety
@@ -193,7 +193,7 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
                     throw std::runtime_error("Failed to unprotect memory.");
                 }
                 credential = DeserializeKeyCredential(protectedData);
-                std::fill(protectedKey.begin(), protectedKey.end(), 0);
+                std::fill(protectedData.begin(), protectedData.end(), 0);
             }
         }
 

--- a/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
@@ -215,6 +215,7 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
         // Derive the encryption/decryption key using HKDF
         IBuffer info = CryptographicBuffer::ConvertStringToBinary(HKDF_INFO, BinaryStringEncoding::Utf8);
         key = DeriveKeyUsingHKDF(signatureBuffer, challengeBuffer, 32, info); // needs to be 32 bytes for SHA256
+        std::fill(signatureData.begin(), signatureData.end(), 0);
 
         return true;
     }

--- a/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
+++ b/src/main/native/org_cryptomator_windows_keychain_WindowsHello_Native.cpp
@@ -243,6 +243,7 @@ bool deriveEncryptionKey(const std::wstring& keyId, const std::vector<uint8_t>& 
         IBuffer info = CryptographicBuffer::ConvertStringToBinary(HKDF_INFO, BinaryStringEncoding::Utf8);
         key = DeriveKeyUsingHKDF(signatureBuffer, challengeBuffer, 32, info); // needs to be 32 bytes for SHA256
         std::fill(signatureData.begin(), signatureData.end(), 0);
+        std::fill(protectCopy.begin(), protectCopy.end(), 0);
 
         return true;
     }


### PR DESCRIPTION
I am glad to request this change to finalize the Windows Hello integration.

Based on an idea from @infeo 

> _"to implement caching only in the integrations-win, as natively as possible. General: Windows Hello only produces a single key and all entries are encrypted with this key. The key is left in memory the first time it is used using CryptProtectMemory. If the user has to log in again, the key must also be reloaded."_

I implemented this as natively as possible. Knowing, that caching secure data is a tradeoff to security, this makes Windows Hello usable, as it reduces the prompts to a required minimum, e.g. on changing the password for a vault.

Basically, the Windows Hello prompt comes up once for every vault used. The sensitive information is keep in memory, but nevertheless protected by `CryptProtectMemory`.

So, after all, this is a gain in security and fits well to the new Touch ID feature on Mac.

This PR depends on a small change in Cryptomator, that the Hello keychain path property needs to be added to the `Environment`. I'll open a separate PR for this.