### PR TITLE
Make library compatible to Windows ARM64 as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ OUT_LIB := $(OUT_DIR)/integrations.lib
 all: install
 
 install:
-	@if not exist "$(OUT_DIR)" mkdir "$(OUT_DIR)"
+ifeq "$(wildcard $(OUT_DIR))" ""
+	mkdir "$(OUT_DIR)"
+endif
 	cl -EHsc -std:c++17 -LD -W4 -guard:cf \
 		-Fe"$(OUT_DLL)" \
 		-Fo"$(OUT_DIR)/" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Note: make apparently thinks, that options specified with "/" are absolute paths and resolves them. see also https://stackoverflow.com/questions/17012419/d9024-make-unrecognized-source-file-type
+ARCH ?= x64
 WIN_SDK_VERSION ?= 10.0.22621.0
 MSVC_VERSION ?= 14.41.34120
 HEADERS := -I"src\main\headers" \
@@ -6,16 +7,20 @@ HEADERS := -I"src\main\headers" \
 	-I"${JAVA_HOME}\include\win32" \
 	-I"C:\Program Files (x86)\Windows Kits\10\Include\$(WIN_SDK_VERSION)\cppwinrt"
 SOURCES := $(wildcard src/main/native/*.cpp)
+OUT_DIR := target/$(ARCH)
+OUT_DLL := src/main/resources/integrations-$(ARCH).dll
+OUT_LIB := $(OUT_DIR)/integrations.lib
 
 ########
 
 all: install
 
 install:
+	@if not exist "$(OUT_DIR)" mkdir "$(OUT_DIR)"
 	cl -EHsc -std:c++17 -LD -W4 -guard:cf \
-		-Fe"src/main/resources/integrations.dll" \
-		-Fo"target/" \
+		-Fe"$(OUT_DLL)" \
+		-Fo"$(OUT_DIR)/" \
 		$(HEADERS) $(SOURCES) \
 		-link -NXCOMPAT -DYNAMICBASE \
-		-implib:target/integrations.lib \
+		-implib:$(OUT_LIB) \
 		crypt32.lib shell32.lib ole32.lib uuid.lib user32.lib Advapi32.lib windowsapp.lib

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project uses the following JVM properties:
 
 * JDK 22
 * Maven
-* MSVC 2022 toolset (e.g. by installing Visual Studio 2022, Workset "Desktop development with C++")
+* MSVC 2022 toolset (e.g. by installing Visual Studio 2022, Workset "Desktop development with C++" and component "MSVC v143 VS 2022 C++ ARM64/ARM64EC-Buildtools")
 * Make (`choco install make`)
 
 ### Build

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
 								<include>*.h</include>
 							</includes>
 						</fileset>
+						<fileset>
+							<directory>${project.basedir}/src/main/resources</directory>
+							<followSymlinks>false</followSymlinks>
+							<includes>
+								<include>*.dll</include>
+							</includes>
+						</fileset>
 					</filesets>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -338,23 +338,39 @@
 						<version>3.5.0</version>
 						<executions>
 							<execution>
+								<id>compile-x64</id>
 								<goals>
 									<goal>exec</goal>
 								</goals>
 								<phase>compile</phase>
 								<configuration>
-									<executable>cmd</executable>
-									<workingDirectory>${project.basedir}</workingDirectory>
-									<environmentVariables>
-										<JAVA_HOME>${java.home}</JAVA_HOME>
-									</environmentVariables>
 									<arguments>
 										<argument>/c</argument>
-										<argument>"${devCommandFileDir}\vcvars64.bat" &amp;&amp; make install &amp;&amp; "${devCommandFileDir}\vcvarsamd64_arm64.bat" &amp;&amp; make install ARCH=arm64</argument>
+										<argument>"${devCommandFileDir}\vcvars64.bat" &amp;&amp; make install</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>compile-arm64</id>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+								<phase>compile</phase>
+								<configuration>
+									<arguments>
+										<argument>/c</argument>
+										<argument>"${devCommandFileDir}\vcvarsamd64_arm64.bat" &amp;&amp; make install ARCH=arm64</argument>
 									</arguments>
 								</configuration>
 							</execution>
 						</executions>
+						<configuration>
+							<executable>cmd</executable>
+							<workingDirectory>${project.basedir}</workingDirectory>
+							<environmentVariables>
+								<JAVA_HOME>${java.home}</JAVA_HOME>
+							</environmentVariables>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,13 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>3.5.0</version>
+						<configuration>
+							<executable>cmd</executable>
+							<workingDirectory>${project.basedir}</workingDirectory>
+							<environmentVariables>
+								<JAVA_HOME>${java.home}</JAVA_HOME>
+							</environmentVariables>
+						</configuration>
 						<executions>
 							<execution>
 								<id>compile-x64</id>
@@ -364,13 +371,6 @@
 								</configuration>
 							</execution>
 						</executions>
-						<configuration>
-							<executable>cmd</executable>
-							<workingDirectory>${project.basedir}</workingDirectory>
-							<environmentVariables>
-								<JAVA_HOME>${java.home}</JAVA_HOME>
-							</environmentVariables>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
 									</environmentVariables>
 									<arguments>
 										<argument>/c</argument>
-										<argument>"${devCommandFileDir}\vcvars64.bat" &amp;&amp; make install</argument>
+										<argument>"${devCommandFileDir}\vcvars64.bat" &amp;&amp; make install &amp;&amp; "${devCommandFileDir}\vcvarsamd64_arm64.bat" &amp;&amp; make install ARCH=arm64</argument>
 									</arguments>
 								</configuration>
 							</execution>

--- a/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
+++ b/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
@@ -14,7 +14,6 @@ public class NativeLibLoader {
 	private static final Logger LOG = LoggerFactory.getLogger(NativeLibLoader.class);
 	private static final String X64_LIB = "/integrations-x64.dll";
 	private static final String ARM64_LIB = "/integrations-arm64.dll";
-	private static String LIBNAME;
 	private static volatile boolean loaded = false;
 
 	/**
@@ -24,6 +23,7 @@ public class NativeLibLoader {
 	public static synchronized void loadLib() {
 		if (!loaded) {
 			var arch = System.getProperty("os.arch");
+			String LIBNAME = "";
 			if (arch.contains("amd64")) {
 				LOG.debug("Loading library for x86_64 architecture");
 				LIBNAME = X64_LIB;

--- a/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
+++ b/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
@@ -12,7 +12,9 @@ import java.util.Objects;
 public class NativeLibLoader {
 
 	private static final Logger LOG = LoggerFactory.getLogger(NativeLibLoader.class);
-	private static final String LIB = "/integrations.dll";
+	private static final String X64_LIB = "/integrations-x64.dll";
+	private static final String ARM64_LIB = "/integrations-arm64.dll";
+	private static String LIBNAME;
 	private static volatile boolean loaded = false;
 
 	/**
@@ -21,18 +23,26 @@ public class NativeLibLoader {
 	 */
 	public static synchronized void loadLib() {
 		if (!loaded) {
-			try (var dll = NativeLibLoader.class.getResourceAsStream(LIB)) {
+			var arch = System.getProperty("os.arch");
+			if (arch.contains("amd64")) {
+				LOG.debug("Loading library for x86_64 architecture");
+				LIBNAME = X64_LIB;
+			} else if (arch.contains("aarch64")) {
+				LOG.debug("Loading library for aarch64 architecture");
+				LIBNAME = ARM64_LIB;
+			}
+			try (var dll = NativeLibLoader.class.getResourceAsStream(LIBNAME)) {
 				Objects.requireNonNull(dll);
 				Path tmpPath = Files.createTempFile("lib", ".dll");
 				Files.copy(dll, tmpPath, StandardCopyOption.REPLACE_EXISTING);
 				System.load(tmpPath.toString());
 				loaded = true;
 			} catch (NullPointerException e) {
-				LOG.error("Did not find resource " + LIB, e);
+				LOG.error("Did not find resource " + LIBNAME, e);
 			} catch (IOException e) {
-				LOG.error("Failed to copy " + LIB + " to temp dir.", e);
+				LOG.error("Failed to copy " + LIBNAME + " to temp dir.", e);
 			} catch (UnsatisfiedLinkError e) {
-				LOG.error("Failed to load lib from " + LIB, e);
+				LOG.error("Failed to load lib from " + LIBNAME, e);
 			}
 		}
 	}

--- a/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
+++ b/src/main/java/org/cryptomator/windows/common/NativeLibLoader.java
@@ -18,19 +18,24 @@ public class NativeLibLoader {
 
 	/**
 	 * Attempts to load the .dll file required for native calls.
+	 *
 	 * @throws UnsatisfiedLinkError If loading the library failed.
 	 */
 	public static synchronized void loadLib() {
 		if (!loaded) {
 			var arch = System.getProperty("os.arch");
-			String LIBNAME = "";
+			final String LIBNAME;
 			if (arch.contains("amd64")) {
 				LOG.debug("Loading library for x86_64 architecture");
 				LIBNAME = X64_LIB;
 			} else if (arch.contains("aarch64")) {
 				LOG.debug("Loading library for aarch64 architecture");
 				LIBNAME = ARM64_LIB;
+			} else {
+				LOG.warn("Unrecognized architecture: {}. Defaulting to x86_64 architecture", arch);
+				LIBNAME = X64_LIB;
 			}
+
 			try (var dll = NativeLibLoader.class.getResourceAsStream(LIBNAME)) {
 				Objects.requireNonNull(dll);
 				Path tmpPath = Files.createTempFile("lib", ".dll");


### PR DESCRIPTION
This requires the component "MSVC v143 VS 2022 C++ ARM64/ARM64EC-Buildtools" for compiling. These [are included](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#workloads-components-and-extensions) in the GitHub windows runner-image, so no adjustment is needed for the GitHub workflow of this lib.