### PR TITLE
Feature: Adjust to integrations-api 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
 		<!-- build plugin dependencies -->
 		<mvn-surefire.version>3.5.3</mvn-surefire.version>
+		<mvn-failsafe.version>3.5.3</mvn-failsafe.version>
 		<dependency-check.version>12.1.1</dependency-check.version>
 		<central-publishing.version>0.7.0</central-publishing.version>
 		<jextract-maven.version>0.4.3</jextract-maven.version>
@@ -219,6 +220,19 @@
 					</statelessTestsetInfoReporter>
 					<argLine>-javaagent:"${net.bytebuddy:byte-buddy-agent:jar}"</argLine>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${mvn-failsafe.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<project.jdk.version>24</project.jdk.version>
 
 		<!-- runtime dependencies -->
-		<api.version>1.5.1</api.version>
+		<api.version>1.6.0</api.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<jackson.version>2.18.3</jackson.version>
 

--- a/src/main/java/org/cryptomator/windows/keychain/WindowsHelloKeychainAccess.java
+++ b/src/main/java/org/cryptomator/windows/keychain/WindowsHelloKeychainAccess.java
@@ -1,5 +1,6 @@
 package org.cryptomator.windows.keychain;
 
+import org.cryptomator.integrations.common.LocalizedDisplayName;
 import org.cryptomator.integrations.common.OperatingSystem;
 import org.cryptomator.integrations.common.Priority;
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
@@ -11,6 +12,7 @@ import org.cryptomator.windows.common.Localization;
  */
 @Priority(1001)
 @OperatingSystem(OperatingSystem.Value.WINDOWS)
+@LocalizedDisplayName(bundle = "WinIntegrationsBundle", key ="org.cryptomator.windows.keychain.displayWindowsHelloName")
 public final class WindowsHelloKeychainAccess extends WindowsKeychainAccessBase {
 
 	private static final String WINDOWS_HELLO_KEYCHAIN_PATHS_PROPERTY = "cryptomator.integrationsWin.windowsHelloKeychainPaths";
@@ -20,10 +22,5 @@ public final class WindowsHelloKeychainAccess extends WindowsKeychainAccessBase 
 	public WindowsHelloKeychainAccess() {
 		super(new FileKeychain(WINDOWS_HELLO_KEYCHAIN_PATHS_PROPERTY),
 				new WindowsHello(System.getProperty(WINDOWS_HELLO_KEY_ID_PROPERTY, "org.cryptomator.integrations-win")));
-	}
-
-	@Override
-	public String displayName() {
-		return Localization.get().getString("org.cryptomator.windows.keychain.displayWindowsHelloName");
 	}
 }

--- a/src/main/java/org/cryptomator/windows/keychain/WindowsKeychainAccessBase.java
+++ b/src/main/java/org/cryptomator/windows/keychain/WindowsKeychainAccessBase.java
@@ -20,7 +20,7 @@ abstract class WindowsKeychainAccessBase implements KeychainAccessProvider {
 	}
 
 	@Override
-	public void storePassphrase(String id, String displayName, CharSequence passphrase, boolean ignored) throws KeychainAccessException {
+	public void storePassphrase(String id, String displayName, CharSequence passphrase) throws KeychainAccessException {
 		var keychainEntry = encryptPassphrase(passphrase);
 		keychain.put(id, keychainEntry);
 	}

--- a/src/main/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccess.java
+++ b/src/main/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccess.java
@@ -1,5 +1,7 @@
 package org.cryptomator.windows.keychain;
 
+import org.cryptomator.integrations.common.DisplayName;
+import org.cryptomator.integrations.common.LocalizedDisplayName;
 import org.cryptomator.integrations.common.OperatingSystem;
 import org.cryptomator.integrations.common.Priority;
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
@@ -11,6 +13,7 @@ import org.cryptomator.windows.common.Localization;
  */
 @Priority(1000)
 @OperatingSystem(OperatingSystem.Value.WINDOWS)
+@LocalizedDisplayName(bundle = "WinIntegrationsBundle", key = "org.cryptomator.windows.keychain.displayName")
 public final class WindowsProtectedKeychainAccess extends WindowsKeychainAccessBase {
 
 	private static final String KEYCHAIN_PATHS_PROPERTY = "cryptomator.integrationsWin.keychainPaths";
@@ -18,11 +21,6 @@ public final class WindowsProtectedKeychainAccess extends WindowsKeychainAccessB
 	//no-arg constructuor required for ServiceLoader
 	public WindowsProtectedKeychainAccess() {
 		super(new FileKeychain(KEYCHAIN_PATHS_PROPERTY),new WinDataProtection());
-	}
-
-	@Override
-	public String displayName() {
-		return Localization.get().getString("org.cryptomator.windows.keychain.displayName");
 	}
 
 }

--- a/src/test/java/org/cryptomator/windows/common/WindowsRegistryIT.java
+++ b/src/test/java/org/cryptomator/windows/common/WindowsRegistryIT.java
@@ -235,7 +235,7 @@ public class WindowsRegistryIT {
 	@DisplayName("Set and get big value data")
 	@Order(11)
 	public void testLottaData() throws WindowsException {
-		var filler = "I like big nums and i cannot lie".repeat(1 << 16); //2 MiB
+		var filler = "I like big nums and i cannot lie".repeat(1 << 15); //1 MiB
 
 		try (var t = WindowsRegistry.startTransaction();
 			 var k = t.createRegKey(RegistryKey.HKEY_CURRENT_USER, "org.cryptomator.integrations-win", true)) {

--- a/src/test/java/org/cryptomator/windows/keychain/WindowsKeychainAccessBaseTest.java
+++ b/src/test/java/org/cryptomator/windows/keychain/WindowsKeychainAccessBaseTest.java
@@ -1,5 +1,6 @@
 package org.cryptomator.windows.keychain;
 
+import org.cryptomator.integrations.common.DisplayName;
 import org.cryptomator.integrations.keychain.KeychainAccessException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -76,15 +77,12 @@ public class WindowsKeychainAccessBaseTest {
 		Assertions.assertArrayEquals(new char[] {'a', 'b', 'c'}, result);
 	}
 
+	@DisplayName("TestProvider")
 	static class TestProvider extends WindowsKeychainAccessBase {
 
 		public TestProvider(Keychain keychain, PassphraseCryptor passphraseCryptor) {
 			super(keychain, passphraseCryptor);
 		}
 
-		@Override
-		public String displayName() {
-			return "TestProvider";
-		}
 	}
 }

--- a/src/test/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccessIntegrationTest.java
+++ b/src/test/java/org/cryptomator/windows/keychain/WindowsProtectedKeychainAccessIntegrationTest.java
@@ -63,7 +63,7 @@ public class WindowsProtectedKeychainAccessIntegrationTest {
 		@DisplayName("A credential can be stored")
 		@Order(3)
 		public void testStoringCredential() throws KeychainAccessException, IOException {
-			keychainAccess.storePassphrase("ozelot", "oZeLoT", "abc", false);
+			keychainAccess.storePassphrase("ozelot", "oZeLoT", "abc");
 			var passphrase = keychainAccess.loadPassphrase("ozelot");
 			Assertions.assertEquals("abc", String.valueOf(passphrase));
 		}
@@ -97,7 +97,7 @@ public class WindowsProtectedKeychainAccessIntegrationTest {
 		@DisplayName("Existing credential can be changed")
 		@Order(7)
 		public void testChangingCredential() throws KeychainAccessException, IOException {
-			keychainAccess.storePassphrase("ozelot", "oZeLoT", "abc", false);
+			keychainAccess.storePassphrase("ozelot", "oZeLoT", "abc");
 			keychainAccess.changePassphrase("ozelot", "oZeLoT", "qwe");
 			var passphrase = keychainAccess.loadPassphrase("ozelot");
 			Assertions.assertEquals("qwe", String.valueOf(passphrase));


### PR DESCRIPTION
This PR updates `integrations-api`  to version 1.6.0 and make the necessary adjustments in the keychainAccessProvider impls.

Addtionally, the mavne failsafe plugin is added to execute integrations tests again.