### PR TITLE
Feature: New signer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,12 @@ jobs:
         run: mvn -B clean test -DdevCommandFileDir="${{ vars.MSVC_DEV_FILES_DIR }}"
       - name: Codesign DLL on release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: skymatic/code-sign-action@v3
+        uses: infeo/workflows/.github/actions/win-sign-action@2572ec671e55288ba840618e89e3d6cf2df701b2
         with:
-          certificate: ${{ secrets.WIN_CODESIGN_P12_BASE64 }}
-          password: ${{ secrets.WIN_CODESIGN_P12_PW }}
-          certificatesha1: 5FC94CE149E5B511E621F53A060AC67CBD446B3A
-          timestampUrl: 'http://timestamp.digicert.com'
-          folder: ./src/main/resources
+          base-dir: src/main/resources
+          file-extensions: dll
+          username: ${{ secrets.WIN_CODESIGN_USERNAME }}
+          password: ${{ secrets.WIN_CODESIGN_PW }}
       - name: Package and Install
         id: packAndInstall
         run: mvn -B install -DskipNativeCompile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,14 @@ jobs:
         id: buildAndTest
         run: mvn -B clean test -DdevCommandFileDir="${{ vars.MSVC_DEV_FILES_DIR }}"
       - name: Codesign DLL on release
-        uses: infeo/workflows/.github/actions/win-sign-action@2572ec671e55288ba840618e89e3d6cf2df701b2
+        uses: skymatic/workflows/.github/actions/win-sign-action@450e322ff2214d0be0b079b63343c894f3ef735f
         with:
           base-dir: src/main/resources
           file-extensions: dll
           username: ${{ secrets.WIN_CODESIGN_USERNAME }}
           password: ${{ secrets.WIN_CODESIGN_PW }}
+          sign-description: 'Cryptomator'
+          sign-url: 'https://cryptomator.org'
       - name: Package and Install
         id: packAndInstall
         run: mvn -B install -DskipNativeCompile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
         id: buildAndTest
         run: mvn -B clean test -DdevCommandFileDir="${{ vars.MSVC_DEV_FILES_DIR }}"
       - name: Codesign DLL on release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: infeo/workflows/.github/actions/win-sign-action@2572ec671e55288ba840618e89e3d6cf2df701b2
         with:
           base-dir: src/main/resources


### PR DESCRIPTION
See https://github.com/cryptomator/cryptomator/pull/3943 for reasons.

The key difference is, that a foreign composite action is used ([skymatic/workflows/win-sign-action](https://github.com/skymatic/workflows/tree/450e322ff2214d0be0b079b63343c894f3ef735f/.github/actions/win-sign-action)).